### PR TITLE
some improvements

### DIFF
--- a/audible2sheet/audible2sheet.py
+++ b/audible2sheet/audible2sheet.py
@@ -106,8 +106,7 @@ class AudibleClient:
         # Try to restore session from file if possible
         try:
             auth = audible.FileAuthenticator(
-                filename=self._session_file, locale=self._locale, 
-                register=True
+                filename=self._session_file, locale=self._locale
             )
             self._client = audible.AudibleAPI(auth)
         except Exception as msg:


### PR DESCRIPTION
- you don't need to ``register=True`` when instantiate a
:class:`audible.auth. FileAuthenticator `
- when you use :class:`audible.auth. LoginAuthenticator` it register
as device by default
- once a device is registered and credentials are stored, you don't
need to use LoginAuthenticator again. If you register you gain a
adp_token and device_cert for requesting api. adp_token and
device_cert never expires. You need no check about this. Only access
token expires after 60 Minutes. But if you use Audible <0.3 you cant
use access_token for request.